### PR TITLE
MAJOR FIX: Fix IReverbApiBroker.GetAvailableDevicesAsync() definition

### DIFF
--- a/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
@@ -9,6 +9,7 @@ namespace DMX.Core.Api.Brokers.ReverbApis
 {
     public partial interface IReverbApiBroker
     {
-        ValueTask<ExternalLabsCollection> GetAvailableDevicesAsync(string reverbServiceId);
+        ValueTask<ExternalLabsCollection> GetAvailableDevicesAsync(
+            ExternalLabsServiceInformation externalLabsServiceInformation);
     }
 }


### PR DESCRIPTION
Closes Task #39745904: MAJOR FIX: Fix IReverbApiBroker.GetAvailableDevicesAsync() definition