### PR TITLE
CODERUB: Rename ExternalLabsCollection.Devices to Labs, fix Models naming conventions

### DIFF
--- a/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.Exceptions.RetrieveAll.cs
+++ b/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.Exceptions.RetrieveAll.cs
@@ -6,7 +6,7 @@ using System;
 using System.Collections.Generic;
 using System.Net.Http;
 using System.Threading.Tasks;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 using DMX.Core.Api.Models.Labs;
 using DMX.Core.Api.Models.Labs.Exceptions;
 using Moq;
@@ -31,8 +31,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 new LabDependencyException(failedExternalLabDependencyException);
 
             this.reverbApiBrokerMock.Setup(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()))
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()))
                         .ThrowsAsync(criticalDependencyException);
 
             // when
@@ -44,8 +44,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 retrieveAllLabsTask.AsTask());
 
             this.reverbApiBrokerMock.Verify(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()),
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()),
                         Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>
@@ -72,8 +72,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 new LabDependencyException(failedExternalLabDependencyException);
 
             this.reverbApiBrokerMock.Setup(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()))
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()))
                         .ThrowsAsync(httpResponseException);
 
             // when
@@ -85,8 +85,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 retrieveAllLabsTask.AsTask());
 
             this.reverbApiBrokerMock.Verify(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()),
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()),
                         Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>
@@ -111,8 +111,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 new LabServiceException(failedExternalLabServiceException);
 
             this.reverbApiBrokerMock.Setup(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()))
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()))
                         .ThrowsAsync(serviceException);
 
             // when
@@ -124,8 +124,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                 retrieveAllLabsTask.AsTask());
 
             this.reverbApiBrokerMock.Verify(broker =>
-                broker.GetAvailableDevicesAsync(
-                    It.IsAny<ExternalLabsServiceInformation>()),
+                broker.GetAvailableLabsAsync(
+                    It.IsAny<ExternalLabServiceInformation>()),
                         Times.Once);
 
             this.loggingBrokerMock.Verify(broker =>

--- a/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.Logic.RetrieveAll.cs
+++ b/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.Logic.RetrieveAll.cs
@@ -5,7 +5,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 using DMX.Core.Api.Models.Labs;
 using FluentAssertions;
 using Moq;
@@ -21,9 +21,9 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
             // given
             List<dynamic> randomLabProperties = CreateRandomLabsProperties();
 
-            var randomExternalLabsCollection = new ExternalLabsCollection
+            var randomExternalLabCollection = new ExternalLabCollection
             {
-                Devices = randomLabProperties.Select(randomProperty =>
+                ExternalLabs = randomLabProperties.Select(randomProperty =>
                     new ExternalLab
                     {
                         Id = randomProperty.Id,
@@ -34,8 +34,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                     }).ToArray()
             };
 
-            ExternalLabsCollection retrievedExternalLabsCollection =
-                randomExternalLabsCollection;
+            ExternalLabCollection retrievedExternalLabCollection =
+                randomExternalLabCollection;
 
             List<Lab> expectedLabs = randomLabProperties.Select(randomproperty =>
                 new Lab
@@ -46,17 +46,17 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
                     Devices = randomproperty.Devices
                 }).ToList();
 
-            var externalLabsServiceInformation =
-                new ExternalLabsServiceInformation
+            var externalLabServiceInformation =
+                new ExternalLabServiceInformation
                 {
                     ServiceId = "Bondi-HW-Lab",
                     ServiceType = "AzureIotHub"
                 };
 
             this.reverbApiBrokerMock.Setup(broker =>
-                broker.GetAvailableDevicesAsync(It.Is(
-                    SameInformationAs(externalLabsServiceInformation))))
-                        .ReturnsAsync(retrievedExternalLabsCollection);
+                broker.GetAvailableLabsAsync(It.Is(
+                    SameInformationAs(externalLabServiceInformation))))
+                        .ReturnsAsync(retrievedExternalLabCollection);
 
             // when
             List<Lab> actualLabs =
@@ -66,8 +66,8 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
             actualLabs.Should().BeEquivalentTo(expectedLabs);
 
             this.reverbApiBrokerMock.Verify(broker =>
-                broker.GetAvailableDevicesAsync(It.Is(
-                    SameInformationAs(externalLabsServiceInformation))),
+                broker.GetAvailableLabsAsync(It.Is(
+                    SameInformationAs(externalLabServiceInformation))),
                         Times.Once);
 
             this.reverbApiBrokerMock.VerifyNoOtherCalls();

--- a/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.cs
+++ b/DMX.Core.Api.Tests.Unit/Services/Foundations/LabServiceTests.cs
@@ -9,7 +9,7 @@ using System.Linq.Expressions;
 using System.Net.Http;
 using DMX.Core.Api.Brokers.Loggings;
 using DMX.Core.Api.Brokers.ReverbApis;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 using DMX.Core.Api.Models.Labs;
 using DMX.Core.Api.Services.Foundations;
 using KellermanSoftware.CompareNetObjects;
@@ -52,13 +52,13 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
             };
         }
 
-        private Expression<Func<ExternalLabsServiceInformation, bool>> SameInformationAs(
-            ExternalLabsServiceInformation expectedExternalLabsServiceInformation)
+        private Expression<Func<ExternalLabServiceInformation, bool>> SameInformationAs(
+            ExternalLabServiceInformation expectedExternalLabServiceInformation)
         {
-            return actualExternalLabsServiceInformation =>
+            return actualExternalLabServiceInformation =>
                 this.compareLogic.Compare(
-                    expectedExternalLabsServiceInformation,
-                    actualExternalLabsServiceInformation)
+                    expectedExternalLabServiceInformation,
+                    actualExternalLabServiceInformation)
                         .AreEqual;
         }
 
@@ -128,15 +128,15 @@ namespace DMX.Core.Api.Tests.Unit.Services.Foundations
         private static int GetRandomNumber() =>
             new IntRange(min: 2, max: 10).GetValue();
 
-        private static ExternalLabsCollection CreateRandomLabCollection() =>
+        private static ExternalLabCollection CreateRandomLabCollection() =>
             CreateExternalLabCollectionFiller().Create();
 
         private static DateTimeOffset GetRandomDateTimeOffset() =>
             new DateTimeRange(earliestDate: new DateTime()).GetValue();
 
-        private static Filler<ExternalLabsCollection> CreateExternalLabCollectionFiller()
+        private static Filler<ExternalLabCollection> CreateExternalLabCollectionFiller()
         {
-            var filler = new Filler<ExternalLabsCollection>();
+            var filler = new Filler<ExternalLabCollection>();
 
             filler.Setup()
                 .OnType<DateTimeOffset?>().Use(GetRandomDateTimeOffset());

--- a/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
@@ -3,13 +3,13 @@
 // ---------------------------------------------------------------
 
 using System.Threading.Tasks;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 
 namespace DMX.Core.Api.Brokers.ReverbApis
 {
     public partial interface IReverbApiBroker
     {
-        ValueTask<ExternalLabsCollection> GetAvailableDevicesAsync(
-            ExternalLabsServiceInformation externalLabsServiceInformation);
+        ValueTask<ExternalLabCollection> GetAvailableDevicesAsync(
+            ExternalLabServiceInformation externalLabsServiceInformation);
     }
 }

--- a/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
@@ -9,7 +9,7 @@ namespace DMX.Core.Api.Brokers.ReverbApis
 {
     public partial interface IReverbApiBroker
     {
-        ValueTask<ExternalLabCollection> GetAvailableDevicesAsync(
+        ValueTask<ExternalLabCollection> GetAvailableLabsAsync(
             ExternalLabServiceInformation externalLabsServiceInformation);
     }
 }

--- a/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/IReverbApiBroker.Devices.cs
@@ -10,6 +10,6 @@ namespace DMX.Core.Api.Brokers.ReverbApis
     public partial interface IReverbApiBroker
     {
         ValueTask<ExternalLabCollection> GetAvailableLabsAsync(
-            ExternalLabServiceInformation externalLabsServiceInformation);
+            ExternalLabServiceInformation externalLabServiceInformation);
     }
 }

--- a/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
@@ -3,18 +3,18 @@
 // ---------------------------------------------------------------
 
 using System.Threading.Tasks;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 
 namespace DMX.Core.Api.Brokers.ReverbApis
 {
     public partial class ReverbApiBroker
     {
-        public async ValueTask<ExternalLabsCollection> GetAvailableDevicesAsync(
-            ExternalLabsServiceInformation externalLabsServiceInformation)
+        public async ValueTask<ExternalLabCollection> GetAvailableDevicesAsync(
+            ExternalLabServiceInformation externalLabsServiceInformation)
         {
             const string RelativeUrl = "api/GetAvailableDevicesAsync";
 
-            return await this.PostAync<ExternalLabsServiceInformation, ExternalLabsCollection>(
+            return await this.PostAync<ExternalLabServiceInformation, ExternalLabCollection>(
                 relativeUrl: $"{RelativeUrl}?code={this.accessKey}",
                 content: externalLabsServiceInformation);
         }

--- a/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
@@ -9,7 +9,7 @@ namespace DMX.Core.Api.Brokers.ReverbApis
 {
     public partial class ReverbApiBroker
     {
-        public async ValueTask<ExternalLabCollection> GetAvailableDevicesAsync(
+        public async ValueTask<ExternalLabCollection> GetAvailableLabsAsync(
             ExternalLabServiceInformation externalLabsServiceInformation)
         {
             const string RelativeUrl = "api/GetAvailableDevicesAsync";

--- a/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
+++ b/DMX.Core.Api/Brokers/ReverbApis/ReverbApiBroker.Devices.cs
@@ -10,13 +10,13 @@ namespace DMX.Core.Api.Brokers.ReverbApis
     public partial class ReverbApiBroker
     {
         public async ValueTask<ExternalLabCollection> GetAvailableLabsAsync(
-            ExternalLabServiceInformation externalLabsServiceInformation)
+            ExternalLabServiceInformation externalLabServiceInformation)
         {
             const string RelativeUrl = "api/GetAvailableDevicesAsync";
 
             return await this.PostAync<ExternalLabServiceInformation, ExternalLabCollection>(
                 relativeUrl: $"{RelativeUrl}?code={this.accessKey}",
-                content: externalLabsServiceInformation);
+                content: externalLabServiceInformation);
         }
     }
 }

--- a/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLab.cs
+++ b/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLab.cs
@@ -5,7 +5,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace DMX.Core.Api.Models.External.ExternalLabs
+namespace DMX.Core.Api.Models.Externals.ExternalLabs
 {
     public class ExternalLab
     {

--- a/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabCollection.cs
+++ b/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabCollection.cs
@@ -4,11 +4,11 @@
 
 using Newtonsoft.Json;
 
-namespace DMX.Core.Api.Models.External.ExternalLabs
+namespace DMX.Core.Api.Models.Externals.ExternalLabs
 {
-    public class ExternalLabsCollection
+    public class ExternalLabCollection
     {
         [JsonProperty("Data")]
-        public ExternalLab[] Devices { get; set; }
+        public ExternalLab[] ExternalLabs { get; set; }
     }
 }

--- a/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabCommand.cs
+++ b/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabCommand.cs
@@ -4,7 +4,7 @@
 
 using System.Collections.Generic;
 
-namespace DMX.Core.Api.Models.External.ExternalLabs
+namespace DMX.Core.Api.Models.Externals.ExternalLabs
 {
     public class ExternalLabCommand
     {

--- a/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabServiceInformation.cs
+++ b/DMX.Core.Api/Models/Externals/ExternalLabs/ExternalLabServiceInformation.cs
@@ -2,9 +2,9 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ---------------------------------------------------------------
 
-namespace DMX.Core.Api.Models.External.ExternalLabs
+namespace DMX.Core.Api.Models.Externals.ExternalLabs
 {
-    public class ExternalLabsServiceInformation
+    public class ExternalLabServiceInformation
     {
         public string ServiceType { get; set; }
         public string ServiceId { get; set; }

--- a/DMX.Core.Api/Services/Foundations/LabService.cs
+++ b/DMX.Core.Api/Services/Foundations/LabService.cs
@@ -2,16 +2,13 @@
 // Copyright (c) Microsoft Corporation. All rights reserved.
 // ---------------------------------------------------------------
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using DMX.Core.Api.Brokers.Loggings;
 using DMX.Core.Api.Brokers.ReverbApis;
-using DMX.Core.Api.Models.External.ExternalLabs;
+using DMX.Core.Api.Models.Externals.ExternalLabs;
 using DMX.Core.Api.Models.Labs;
-using DMX.Core.Api.Models.Labs.Exceptions;
-using RESTFulSense.Exceptions;
 
 namespace DMX.Core.Api.Services.Foundations
 {
@@ -31,16 +28,16 @@ namespace DMX.Core.Api.Services.Foundations
         public ValueTask<List<Lab>> RetrieveAllLabsAsync() =>
         TryCatch(async () =>
         {
-            var externalLabsServiceInformation = new ExternalLabsServiceInformation
+            var externalLabServiceInformation = new ExternalLabServiceInformation
             {
                 ServiceId = "Bondi-HW-Lab",
                 ServiceType = "AzureIotHub"
             };
 
-            ExternalLabsCollection externalLabsCollection =
-                await this.reverbApiBroker.GetAvailableDevicesAsync(externalLabsServiceInformation);
+            ExternalLabCollection externalLabCollection =
+                await this.reverbApiBroker.GetAvailableLabsAsync(externalLabServiceInformation);
 
-            List<ExternalLab> externalLabs = externalLabsCollection.Devices.ToList();
+            List<ExternalLab> externalLabs = externalLabCollection.ExternalLabs.ToList();
 
             return externalLabs.Select(externalLab =>
                 new Lab


### PR DESCRIPTION
Closes Task #39733541: CODERUB: Rename ExternalLabsCollection.Devices to Labs